### PR TITLE
Salto Deployment: GWR Feature B3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+## [GWR Feature B3](https://app.salto.io/orgs/3ab0fb5b-95a7-497b-836a-2583702766e1/envs/13ce49a9-3991-4887-8e55-c9417403d834/deployments/f627e869-741d-4d0f-90c1-346b8431e3d9)
+
+Source Environment: Snapshot from 09/22/2023 @ 8:17 pm of [gwr-cpq-dev](https://app.salto.io/orgs/3ab0fb5b-95a7-497b-836a-2583702766e1/envs/0a26431d-6e6e-4ffa-85df-2b122bef50ac)
+
+Target Environment: [gwr-cpq-prod](https://app.salto.io/orgs/3ab0fb5b-95a7-497b-836a-2583702766e1/envs/13ce49a9-3991-4887-8e55-c9417403d834) 
+
+Author: Geoffrey Routledge


### PR DESCRIPTION

Salto [deployment](https://app.salto.io/orgs/3ab0fb5b-95a7-497b-836a-2583702766e1/envs/13ce49a9-3991-4887-8e55-c9417403d834/deployments/f627e869-741d-4d0f-90c1-346b8431e3d9) from an older version of gwr-cpq-dev (09/22/2023 @ 8:17 pm) to gwr-cpq-prod.

promoting 'GWR Feature B3'

Related deployments:
[GWR Feature B3](https://app.salto.io/orgs/3ab0fb5b-95a7-497b-836a-2583702766e1/envs/13ce49a9-3991-4887-8e55-c9417403d834/deployments/b87dcf26-a14a-4049-a9da-e282b97edd0f)
