### PR TITLE
Salto Deployment: recover after refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+## [recover after refresh](https://app.salto.io/orgs/3ab0fb5b-95a7-497b-836a-2583702766e1/envs/13ce49a9-3991-4887-8e55-c9417403d834/deployments/d153baec-a2c3-4a70-b973-9847b3171773)
+
+Source Environment: Snapshot from 09/18/2023 @ 11:05 pm of [gwr-cpq-prod](https://app.salto.io/orgs/3ab0fb5b-95a7-497b-836a-2583702766e1/envs/13ce49a9-3991-4887-8e55-c9417403d834)
+
+Target Environment: [gwr-cpq-prod](https://app.salto.io/orgs/3ab0fb5b-95a7-497b-836a-2583702766e1/envs/13ce49a9-3991-4887-8e55-c9417403d834) 
+
+Author: Geoffrey Routledge
+
+To include additional edits in this deployment, commit edits to the PR after branch.

--- a/envs/gwr-cpq-prod/salesforce/Records/ApexClass/AccountController.nacl
+++ b/envs/gwr-cpq-prod/salesforce/Records/ApexClass/AccountController.nacl
@@ -1,0 +1,18 @@
+salesforce.ApexClass AccountController {
+  apiVersion = 58
+  status = "Active"
+  fullName = "AccountController"
+  content = file("salesforce/Records/ApexClass/AccountController.cls")
+  _generated_dependencies = [
+    {
+      reference = salesforce.Account
+    },
+    {
+      reference = salesforce.Account.field.Active__c
+    },
+    {
+      reference = salesforce.Account.field.SLA__c
+    },
+  ]
+  _alias = "AccountController"
+}

--- a/envs/gwr-cpq-prod/salesforce/Records/ApexClass/gwr_class2.nacl
+++ b/envs/gwr-cpq-prod/salesforce/Records/ApexClass/gwr_class2.nacl
@@ -1,0 +1,7 @@
+salesforce.ApexClass gwr_class2 {
+  apiVersion = 58
+  status = "Active"
+  fullName = "gwr_class2"
+  content = file("salesforce/Records/ApexClass/gwr_class2.cls")
+  _alias = "gwr_class2"
+}

--- a/envs/gwr-cpq-prod/static-resources/salesforce/Records/ApexClass/AccountController.cls
+++ b/envs/gwr-cpq-prod/static-resources/salesforce/Records/ApexClass/AccountController.cls
@@ -1,0 +1,10 @@
+public with sharing class AccountController {
+    public static List<Account> getAllActiveAccounts() {
+      return [SELECT Id, SLA__c, Name, Active__c FROM Account WHERE Active__c = 'Yes' WITH SECURITY_ENFORCED];
+    }
+    // more code added....
+
+    /*
+    even more code changes
+    */
+}

--- a/envs/gwr-cpq-prod/static-resources/salesforce/Records/ApexClass/gwr_class2.cls
+++ b/envs/gwr-cpq-prod/static-resources/salesforce/Records/ApexClass/gwr_class2.cls
@@ -1,0 +1,5 @@
+public with sharing class gwr_class2 {
+    public gwr_class2() {
+
+    }
+}


### PR DESCRIPTION

Salto [deployment](https://app.salto.io/orgs/3ab0fb5b-95a7-497b-836a-2583702766e1/envs/13ce49a9-3991-4887-8e55-c9417403d834/deployments/d153baec-a2c3-4a70-b973-9847b3171773) from an older version of gwr-cpq-prod (09/18/2023 @ 11:05 pm) to gwr-cpq-prod.




