### PR TITLE
Salto Deployment: test LeadSource global valueset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+## [test LeadSource global valueset](https://app.salto.io/orgs/3ab0fb5b-95a7-497b-836a-2583702766e1/envs/13ce49a9-3991-4887-8e55-c9417403d834/deployments/38a3519e-8dc5-4af6-b83a-bd5134273af9)
+
+Source Environment: [gwr-cpq-dev](https://app.salto.io/orgs/3ab0fb5b-95a7-497b-836a-2583702766e1/envs/0a26431d-6e6e-4ffa-85df-2b122bef50ac)
+
+Target Environment: [gwr-cpq-prod](https://app.salto.io/orgs/3ab0fb5b-95a7-497b-836a-2583702766e1/envs/13ce49a9-3991-4887-8e55-c9417403d834) 
+
+Author: Geoffrey Routledge
+
+To include additional edits in this deployment, commit edits to the PR after branch.

--- a/envs/gwr-cpq-prod/salesforce/Records/StandardValueSet/LeadSource.nacl
+++ b/envs/gwr-cpq-prod/salesforce/Records/StandardValueSet/LeadSource.nacl
@@ -27,6 +27,11 @@ salesforce.StandardValueSet LeadSource {
       default = false
       label = "Other"
     },
+    {
+      fullName = "GWR Lead"
+      default = false
+      label = "GWR Lead"
+    },
   ]
   _alias = "LeadSource"
 }


### PR DESCRIPTION

Salto [deployment](https://app.salto.io/orgs/3ab0fb5b-95a7-497b-836a-2583702766e1/envs/13ce49a9-3991-4887-8e55-c9417403d834/deployments/38a3519e-8dc5-4af6-b83a-bd5134273af9) from gwr-cpq-dev to gwr-cpq-prod.
Deployer: Geoffrey Routledge (geoffrey.routledge@salto.io)



